### PR TITLE
Uses Bublé v0.15.2, default pattern (JS/JSX) and fix dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # buble-brunch 4.2.3 (Jan 5, 2017)
 * API Change: use `buble` instead of `bubleBrunch` as the key for the config.
+* Uses Bublé v0.15.2
+* Uses default js/jsx if not pattern is passed as option.
+* Moved [anymatch](https://npmjs.org/package/anymatch) and [flatten-brunch-map](https://npmjs.org/package/flatten-brunch-map) to dependencies in package.json.
 
 # buble-brunch 3.2.3 (Dec 8, 2016)
 * Improve the compatibility with older versions of node

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ class BrunchBuble {
       this.options.sourceMap !== false &&
       this.options.sourceMaps !== false;
 
-    this.pattern = this.options.pattern;
+    if (this.options.pattern) this.pattern = this.options.pattern;
     this.ignored = anymatch(this.options.ignore || reIgnore);
   }
 

--- a/package.json
+++ b/package.json
@@ -34,16 +34,16 @@
     "test": "eslint ."
   },
   "dependencies": {
-    "buble": "^0.14.2"
+    "buble": "^0.15.2",
+    "anymatch": "^1.3.0",
+    "flatten-brunch-map": "^2.8.1"
   },
   "peerDependencies": {
     "brunch": "^2.10.3"
   },
   "devDependencies": {
-    "anymatch": "^1.3.0",
     "eslint": "^3.14.0",
-    "eslint-config-brunch": "brunch/eslint-config-brunch",
-    "flatten-brunch-map": "^2.8.1"
+    "eslint-config-brunch": "brunch/eslint-config-brunch"
   },
   "eslintConfig": {
     "extends": "brunch"


### PR DESCRIPTION
* Uses Bublé v0.15.2
* Uses default pattern (js/jsx)
* Fix dependencies